### PR TITLE
specify getrandom "std" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/jedisct1/rust-minisign"
 
 [dependencies]
 base64 = "0.10"
-getrandom = "0.1.3"
+getrandom = { version = "0.1.3", features = ["std"] }
 scrypt = { version = "0.2", default-features = false }
 
 [target.'cfg(any(windows, unix))'.dependencies]


### PR DESCRIPTION
getrandom has a semver-breaking change in 0.1.10, where the
`std::error::Error` impl for `getrandom::Error` disappeared for linux,
macos, and other OSes disappeared unless the `std` feature was
specified. specifying `std` as a feature is backwards-compatible with
old getrandom versions, and arguably `std::error::Error` being present
for any target OS regardless of `std` being present was an error in the
first place.