### PR TITLE
Exposing the keynum for public keys, secret keys and signatures

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -75,6 +75,11 @@ pub struct PublicKey {
 }
 
 impl PublicKey {
+    /// The key identifier of this public key.
+    pub fn keynum(&self) -> &[u8] {
+        &self.keynum_pk.keynum[..]
+    }
+
     /// Deserialize a `PublicKey`.
     ///
     /// For storage, a `PublicKeyBox` is usually what you need instead.

--- a/src/secret_key.rs
+++ b/src/secret_key.rs
@@ -132,6 +132,11 @@ impl SecretKey {
         Ok(self)
     }
 
+    /// The key identifier of this secret key.
+    pub fn keynum(&self) -> &[u8] {
+        &self.keynum_sk.keynum[..]
+    }
+
     /// Deserialize a `SecretKey`.
     ///
     /// For storage, a `SecretKeyBox` is usually what you need instead.

--- a/src/signature_box.rs
+++ b/src/signature_box.rs
@@ -60,6 +60,11 @@ impl SignatureBox {
         Ok(just_comment)
     }
 
+    /// The key identifier used to create the signature.
+    pub fn keynum(&self) -> &[u8] {
+        &self.signature.keynum[..]
+    }
+
     /// Create a new `SignatureBox` from a string.
     pub fn from_string(s: &str) -> Result<SignatureBox> {
         let mut lines = s.lines();


### PR DESCRIPTION
This PR exposes the key identifier of keys and signatures, which is needed in some cases (and is part of the documented format).