### PR TITLE
Fix empty password makes the sk unusable

### DIFF
--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -22,7 +22,7 @@ impl KeyPair {
     ///
     /// The secret key will not be protected by a password.
     ///
-    /// This is not recommended and incompatible with other implementations,
+    /// This is not recommended,
     /// but can be necessary if using a password is really not an option
     /// for your application.
     ///
@@ -143,7 +143,7 @@ impl KeyPair {
     /// The secret key will not be protected by a password,
     /// and keys will be stored as raw bytes, not as a box.
     ///
-    /// This is not recommended and incompatible with other implementations,
+    /// This is not recommended,
     /// but can be necessary if using a password is not an option
     /// for your application.
     ///

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -61,21 +61,12 @@ impl KeyPair {
     ///
     /// If `password` is `None`, a password will be interactively asked for.
     ///
+    /// If the password is an empty string, the secret key will be unecrypted (same as [`Self::generate_unencrypted_keypair`])
+    ///
     /// A key can be converted to a box in order to be serialized and saved.
     /// Ex: `pk.to_box()?.to_bytes()`
     pub fn generate_encrypted_keypair(password: Option<String>) -> Result<Self> {
         let KeyPair { pk, mut sk } = Self::generate_unencrypted_keypair()?;
-
-        let opslimit = OPSLIMIT;
-        let memlimit = MEMLIMIT;
-        let mut kdf_salt = [0u8; KDF_SALTBYTES];
-        getrandom(&mut kdf_salt)?;
-        sk.kdf_alg = KDF_ALG;
-        sk.kdf_salt = kdf_salt;
-        sk.kdf_opslimit_le = store_u64_le(opslimit);
-        sk.kdf_memlimit_le = store_u64_le(memlimit as u64);
-        sk.write_checksum()
-            .map_err(|_| PError::new(ErrorKind::Generate, "failed to hash and write checksum!"))?;
 
         let interactive = password.is_none();
         let password = match password {
@@ -100,6 +91,18 @@ impl KeyPair {
             }
         };
         if !password.is_empty() {
+            let opslimit = OPSLIMIT;
+            let memlimit = MEMLIMIT;
+            let mut kdf_salt = [0u8; KDF_SALTBYTES];
+            getrandom(&mut kdf_salt)?;
+            sk.kdf_alg = KDF_ALG;
+            sk.kdf_salt = kdf_salt;
+            sk.kdf_opslimit_le = store_u64_le(opslimit);
+            sk.kdf_memlimit_le = store_u64_le(memlimit as u64);
+            sk.write_checksum().map_err(|_| {
+                PError::new(ErrorKind::Generate, "failed to hash and write checksum!")
+            })?;
+
             sk = sk.encrypt(password)?;
         } else if interactive {
             writeln!(io::stdout(), "done").map_err(|e| PError::new(ErrorKind::Io, e))?;

--- a/src/secret_key.rs
+++ b/src/secret_key.rs
@@ -246,7 +246,7 @@ impl SecretKey {
                 KDF_NONE => {
                     return Err(PError::new(
                         ErrorKind::Io,
-                        "Key might be encrypted".to_string(),
+                        "Key might not be encrypted".to_string(),
                     ))
                 }
                 KDF_ALG => {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -264,12 +264,12 @@ fn unencrypted_key() {
 
 #[test]
 fn empty_key_makes_unencrypted_key() {
-    use crate::{KeyPair, SecretKey};
+    use crate::KeyPair;
 
-    let KeyPair { pk, sk } = KeyPair::generate_encrypted_keypair(Some("".to_owned())).unwrap();
+    let password = Some("".to_owned());
+    let KeyPair { pk, sk } = KeyPair::generate_encrypted_keypair(password.clone()).unwrap();
     _ = pk;
     let sk_box = sk.to_box(None).unwrap();
-    let sk2 = SecretKey::from_box(sk_box.clone(), Some("".to_string()));
-    assert!(sk2.is_err());
-    SecretKey::from_unencrypted_box(sk_box).unwrap();
+    assert!(sk_box.clone().into_secret_key(password).is_err());
+    sk_box.into_unencrypted_secret_key().unwrap();
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -261,3 +261,15 @@ fn unencrypted_key() {
     assert!(sk2.is_err());
     SecretKey::from_unencrypted_box(sk_box).unwrap();
 }
+
+#[test]
+fn empty_key_makes_unencrypted_key() {
+    use crate::{KeyPair, SecretKey};
+
+    let KeyPair { pk, sk } = KeyPair::generate_encrypted_keypair(Some("".to_owned())).unwrap();
+    _ = pk;
+    let sk_box = sk.to_box(None).unwrap();
+    let sk2 = SecretKey::from_box(sk_box.clone(), Some("".to_string()));
+    assert!(sk2.is_err());
+    SecretKey::from_unencrypted_box(sk_box).unwrap();
+}


### PR DESCRIPTION
Fix passing in an empty password to `generate_encrypted_keypair` (or from its prompts) makes the generated secret key not useable (can't be decoded through both `into_secret_key` and `into_unencrypted_secret_key`)

Reference https://github.com/tauri-apps/tauri/issues/14829